### PR TITLE
Handle repository lookup errors during registration

### DIFF
--- a/internal/services/auth.go
+++ b/internal/services/auth.go
@@ -43,7 +43,14 @@ func (s *AuthService) Register(ctx context.Context, req models.RegisterRequest) 
 	}
 
 	// проверяем уникальность email
-	if existing, _ := s.repo.GetByEmail(ctx, req.Email); existing != nil {
+	existing, err := s.repo.GetByEmail(ctx, req.Email)
+	switch {
+	case errors.Is(err, repository.ErrNotFound):
+		// ничего не делаем — такого email ещё нет
+	case err != nil:
+		s.log.Errorw("user_lookup_failed", "email", req.Email, "err", err)
+		return nil, err
+	case existing != nil:
 		return nil, ErrEmailTaken
 	}
 

--- a/internal/services/auth_test.go
+++ b/internal/services/auth_test.go
@@ -2,12 +2,12 @@ package services_test
 
 import (
 	"context"
-	"errors"
-	"github.com/Ramcache/travel-backend/internal/helpers"
 	"testing"
 	"time"
 
+	"github.com/Ramcache/travel-backend/internal/helpers"
 	"github.com/Ramcache/travel-backend/internal/models"
+	"github.com/Ramcache/travel-backend/internal/repository"
 	"github.com/Ramcache/travel-backend/internal/services"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -78,7 +78,7 @@ func TestAuthService_Register_Success(t *testing.T) {
 	svc := services.NewAuthService(repo, "secret", 24*time.Hour, zaptest.NewLogger(t).Sugar())
 
 	repo.On("GetByEmail", mock.Anything, "new@mail.com").
-		Return((*models.User)(nil), errors.New("not found"))
+		Return((*models.User)(nil), repository.ErrNotFound)
 	repo.On("Create", mock.Anything, mock.AnythingOfType("*models.User")).
 		Return(nil)
 
@@ -95,7 +95,7 @@ func TestAuthService_Login_UserNotFound(t *testing.T) {
 	svc := services.NewAuthService(repo, "secret", 24*time.Hour, zaptest.NewLogger(t).Sugar())
 
 	repo.On("GetByEmail", mock.Anything, "a@b.com").
-		Return((*models.User)(nil), errors.New("not found"))
+		Return((*models.User)(nil), repository.ErrNotFound)
 
 	token, err := svc.Login(context.Background(), models.LoginRequest{
 		Email: "a@b.com", Password: "123",
@@ -154,7 +154,7 @@ func TestAuthService_GetByID_NotFound(t *testing.T) {
 	repo := new(MockUserRepo)
 	svc := services.NewAuthService(repo, "secret", 24*time.Hour, zaptest.NewLogger(t).Sugar())
 
-	repo.On("GetByID", mock.Anything, 99).Return((*models.User)(nil), errors.New("not found"))
+	repo.On("GetByID", mock.Anything, 99).Return((*models.User)(nil), repository.ErrNotFound)
 
 	u, err := svc.GetByID(context.Background(), 99)
 	assert.Nil(t, u)

--- a/internal/services/trip_test.go
+++ b/internal/services/trip_test.go
@@ -2,10 +2,10 @@ package services_test
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/Ramcache/travel-backend/internal/models"
+	"github.com/Ramcache/travel-backend/internal/repository"
 	"github.com/Ramcache/travel-backend/internal/services"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -125,7 +125,7 @@ func TestTripService_Get_NotFound(t *testing.T) {
 		zaptest.NewLogger(t).Sugar(),
 	)
 
-	mockRepo.On("GetByID", mock.Anything, 99).Return((*models.Trip)(nil), errors.New("not found"))
+	mockRepo.On("GetByID", mock.Anything, 99).Return((*models.Trip)(nil), repository.ErrNotFound)
 
 	trip, err := svc.Get(context.Background(), 99)
 	assert.Nil(t, trip)


### PR DESCRIPTION
## Summary
- return repository lookup errors during user registration instead of ignoring them
- align auth and trip service tests with repository ErrNotFound sentinel

## Testing
- go test ./...
- go vet ./...


------
https://chatgpt.com/codex/tasks/task_e_68d6500e911c832c911bb3b72fd6c942