### PR TITLE
Add test coverage for config and helper utilities

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,8 +96,10 @@ func getEnvDuration(key string, def time.Duration) time.Duration {
 	return def
 }
 
+var cgroupFilePath = "/proc/1/cgroup"
+
 func isRunningInDocker() bool {
-	if f, err := os.ReadFile("/proc/1/cgroup"); err == nil {
+	if f, err := os.ReadFile(cgroupFilePath); err == nil {
 		return strings.Contains(string(f), "docker")
 	}
 	return false

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,178 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGetEnv(t *testing.T) {
+	const key = "TEST_CONFIG_GET_ENV"
+	os.Unsetenv(key)
+
+	if got := getEnv(key, "default"); got != "default" {
+		t.Fatalf("expected default value, got %q", got)
+	}
+
+	if err := os.Setenv(key, "value"); err != nil {
+		t.Fatalf("setenv: %v", err)
+	}
+	defer os.Unsetenv(key)
+
+	if got := getEnv(key, "default"); got != "value" {
+		t.Fatalf("expected overridden value, got %q", got)
+	}
+}
+
+func TestGetEnvInt(t *testing.T) {
+	const key = "TEST_CONFIG_GET_ENV_INT"
+	os.Unsetenv(key)
+
+	if got := getEnvInt(key, 42); got != 42 {
+		t.Fatalf("expected default value, got %d", got)
+	}
+
+	if err := os.Setenv(key, "100"); err != nil {
+		t.Fatalf("setenv: %v", err)
+	}
+	if got := getEnvInt(key, 42); got != 100 {
+		t.Fatalf("expected parsed value, got %d", got)
+	}
+
+	if err := os.Setenv(key, "not-a-number"); err != nil {
+		t.Fatalf("setenv: %v", err)
+	}
+	if got := getEnvInt(key, 7); got != 7 {
+		t.Fatalf("expected fallback on parse error, got %d", got)
+	}
+
+	os.Unsetenv(key)
+}
+
+func TestGetEnvDuration(t *testing.T) {
+	const key = "TEST_CONFIG_GET_ENV_DURATION"
+	os.Unsetenv(key)
+
+	defaultDuration := 30 * time.Second
+	if got := getEnvDuration(key, defaultDuration); got != defaultDuration {
+		t.Fatalf("expected default duration, got %s", got)
+	}
+
+	if err := os.Setenv(key, "45s"); err != nil {
+		t.Fatalf("setenv: %v", err)
+	}
+	if got := getEnvDuration(key, defaultDuration); got != 45*time.Second {
+		t.Fatalf("expected parsed duration, got %s", got)
+	}
+
+	if err := os.Setenv(key, "not-a-duration"); err != nil {
+		t.Fatalf("setenv: %v", err)
+	}
+	if got := getEnvDuration(key, defaultDuration); got != defaultDuration {
+		t.Fatalf("expected fallback on parse error, got %s", got)
+	}
+
+	os.Unsetenv(key)
+}
+
+func TestIsRunningInDocker(t *testing.T) {
+	originalPath := cgroupFilePath
+	t.Cleanup(func() { cgroupFilePath = originalPath })
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "cgroup")
+
+	if err := os.WriteFile(file, []byte("12:freezer:/docker/123"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	cgroupFilePath = file
+	if !isRunningInDocker() {
+		t.Fatal("expected docker detection to return true")
+	}
+
+	if err := os.WriteFile(file, []byte("12:freezer:/container"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	if isRunningInDocker() {
+		t.Fatal("expected docker detection to return false")
+	}
+}
+
+func TestLoad(t *testing.T) {
+	originalPath := cgroupFilePath
+	t.Cleanup(func() { cgroupFilePath = originalPath })
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "cgroup")
+	if err := os.WriteFile(file, []byte("docker"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	cgroupFilePath = file
+
+	envs := map[string]string{
+		"APP_ENV":         "prod",
+		"APP_PORT":        "9090",
+		"APP_JWT_SECRET":  "supersecret",
+		"JWT_TTL":         "1h",
+		"FRONTEND_URL":    "https://example.com",
+		"DB_URL":          "postgres://localhost:5432/app",
+		"DB_MAX_CONNS":    "20",
+		"DB_MIN_CONNS":    "5",
+		"DB_CONN_TIMEOUT": "10s",
+		"DB_IDLE_TIMEOUT": "2m",
+		"TG_TOKEN":        "token",
+		"TG_CHAT":         "chat",
+	}
+
+	for k, v := range envs {
+		if err := os.Setenv(k, v); err != nil {
+			t.Fatalf("setenv %s: %v", k, err)
+		}
+		t.Cleanup(func(key string) func() {
+			return func() { os.Unsetenv(key) }
+		}(k))
+	}
+
+	cfg := Load()
+
+	if cfg.AppEnv != "prod" {
+		t.Fatalf("expected AppEnv prod, got %s", cfg.AppEnv)
+	}
+	if cfg.AppPort != "9090" {
+		t.Fatalf("expected AppPort 9090, got %s", cfg.AppPort)
+	}
+	if cfg.JWTSecret != "supersecret" {
+		t.Fatalf("expected JWTSecret supersecret, got %s", cfg.JWTSecret)
+	}
+	if cfg.JWTTTL != time.Hour {
+		t.Fatalf("expected JWTTTL 1h, got %s", cfg.JWTTTL)
+	}
+	if cfg.FrontendURL != "https://example.com" {
+		t.Fatalf("expected FrontendURL https://example.com, got %s", cfg.FrontendURL)
+	}
+
+	if !strings.Contains(cfg.DB.URL, "host.docker.internal") {
+		t.Fatalf("expected DB URL adjusted for docker, got %s", cfg.DB.URL)
+	}
+	if cfg.DB.MaxConns != 20 {
+		t.Fatalf("expected DB MaxConns 20, got %d", cfg.DB.MaxConns)
+	}
+	if cfg.DB.MinConns != 5 {
+		t.Fatalf("expected DB MinConns 5, got %d", cfg.DB.MinConns)
+	}
+	if cfg.DB.ConnTimeout != 10*time.Second {
+		t.Fatalf("expected DB ConnTimeout 10s, got %s", cfg.DB.ConnTimeout)
+	}
+	if cfg.DB.IdleTimeout != 2*time.Minute {
+		t.Fatalf("expected DB IdleTimeout 2m, got %s", cfg.DB.IdleTimeout)
+	}
+	if cfg.TG.TelegramToken != "token" {
+		t.Fatalf("expected TG token token, got %s", cfg.TG.TelegramToken)
+	}
+	if cfg.TG.TelegramChat != "chat" {
+		t.Fatalf("expected TG chat chat, got %s", cfg.TG.TelegramChat)
+	}
+}

--- a/internal/helpers/context_test.go
+++ b/internal/helpers/context_test.go
@@ -1,0 +1,20 @@
+package helpers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Ramcache/travel-backend/internal/helpers"
+)
+
+func TestSetAndGetUserID(t *testing.T) {
+	ctx := context.Background()
+	if got := helpers.GetUserID(ctx); got != 0 {
+		t.Fatalf("expected zero value when user id not set, got %d", got)
+	}
+
+	ctx = helpers.SetUserID(ctx, 42)
+	if got := helpers.GetUserID(ctx); got != 42 {
+		t.Fatalf("expected user id 42, got %d", got)
+	}
+}

--- a/internal/helpers/errors_test.go
+++ b/internal/helpers/errors_test.go
@@ -1,0 +1,23 @@
+package helpers_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Ramcache/travel-backend/internal/helpers"
+)
+
+func TestErrInvalidInput(t *testing.T) {
+	err := helpers.ErrInvalidInput("bad input")
+	if err.Error() != "bad input" {
+		t.Fatalf("expected error message to be preserved, got %q", err.Error())
+	}
+
+	if !helpers.IsInvalidInput(err) {
+		t.Fatal("expected error to be recognized as InvalidInputError")
+	}
+
+	if helpers.IsInvalidInput(errors.New("other")) {
+		t.Fatal("expected IsInvalidInput to return false for other error types")
+	}
+}

--- a/internal/helpers/paginated_test.go
+++ b/internal/helpers/paginated_test.go
@@ -1,0 +1,25 @@
+package helpers_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Ramcache/travel-backend/internal/helpers"
+)
+
+func TestPaginatedResponseJSON(t *testing.T) {
+	resp := helpers.PaginatedResponse[int]{
+		Total: 2,
+		Items: []int{1, 2},
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("json marshal: %v", err)
+	}
+
+	expected := `{"total":2,"items":[1,2]}`
+	if string(data) != expected {
+		t.Fatalf("expected %s, got %s", expected, string(data))
+	}
+}

--- a/internal/helpers/telegram.go
+++ b/internal/helpers/telegram.go
@@ -9,6 +9,13 @@ import (
 	"net/url"
 )
 
+var (
+	httpPostForm = http.PostForm
+	httpPostJSON = func(url, contentType string, body io.Reader) (*http.Response, error) {
+		return http.Post(url, contentType, body)
+	}
+)
+
 type TelegramClient struct {
 	Token  string
 	ChatID string
@@ -21,7 +28,7 @@ func NewTelegramClient(token, chatID string) *TelegramClient {
 func (t *TelegramClient) SendMessage(text string) error {
 	apiURL := fmt.Sprintf("https://api.telegram.org/bot%s/sendMessage", t.Token)
 
-	resp, err := http.PostForm(apiURL, url.Values{
+	resp, err := httpPostForm(apiURL, url.Values{
 		"chat_id":    {t.ChatID},
 		"text":       {text},
 		"parse_mode": {"HTML"},
@@ -57,7 +64,7 @@ func (t *TelegramClient) SendMessageWithButton(text, buttonText, buttonURL strin
 	}
 
 	body, _ := json.Marshal(payload)
-	resp, err := http.Post(apiURL, "application/json", bytes.NewReader(body))
+	resp, err := httpPostJSON(apiURL, "application/json", bytes.NewReader(body))
 	if err != nil {
 		return err
 	}

--- a/internal/helpers/telegram_test.go
+++ b/internal/helpers/telegram_test.go
@@ -1,0 +1,132 @@
+package helpers
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestNewTelegramClient(t *testing.T) {
+	client := NewTelegramClient("token", "chat")
+	if client.Token != "token" || client.ChatID != "chat" {
+		t.Fatalf("unexpected client fields: %+v", client)
+	}
+}
+
+func TestSendMessageSuccess(t *testing.T) {
+	client := NewTelegramClient("token", "chat")
+
+	called := false
+	httpPostForm = func(url string, data url.Values) (*http.Response, error) {
+		called = true
+		if data.Get("chat_id") != "chat" {
+			t.Fatalf("unexpected chat id %s", data.Get("chat_id"))
+		}
+		if data.Get("text") != "hello" {
+			t.Fatalf("unexpected text %s", data.Get("text"))
+		}
+		return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Body: io.NopCloser(strings.NewReader(""))}, nil
+	}
+	t.Cleanup(func() { httpPostForm = http.PostForm })
+
+	if err := client.SendMessage("hello"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !called {
+		t.Fatal("expected httpPostForm to be called")
+	}
+}
+
+func TestSendMessageHTTPError(t *testing.T) {
+	client := NewTelegramClient("token", "chat")
+
+	httpPostForm = func(string, url.Values) (*http.Response, error) {
+		return nil, errors.New("network")
+	}
+	t.Cleanup(func() { httpPostForm = http.PostForm })
+
+	if err := client.SendMessage("hello"); err == nil || !strings.Contains(err.Error(), "network") {
+		t.Fatalf("expected network error, got %v", err)
+	}
+}
+
+func TestSendMessageNon200(t *testing.T) {
+	client := NewTelegramClient("token", "chat")
+
+	httpPostForm = func(string, url.Values) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad Request", Body: io.NopCloser(strings.NewReader("bad"))}, nil
+	}
+	t.Cleanup(func() { httpPostForm = http.PostForm })
+
+	if err := client.SendMessage("hello"); err == nil || !strings.Contains(err.Error(), "telegram send failed") {
+		t.Fatalf("expected telegram send failure, got %v", err)
+	}
+}
+
+func TestSendMessageWithButtonSuccess(t *testing.T) {
+	client := NewTelegramClient("token", "chat")
+
+	httpPostJSON = func(url, contentType string, body io.Reader) (*http.Response, error) {
+		if !strings.Contains(url, "token") {
+			t.Fatalf("unexpected url %s", url)
+		}
+		if contentType != "application/json" {
+			t.Fatalf("unexpected content type %s", contentType)
+		}
+		data, err := io.ReadAll(body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if !strings.Contains(string(data), "button") {
+			t.Fatalf("expected button text in payload, got %s", string(data))
+		}
+		return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Body: io.NopCloser(strings.NewReader(""))}, nil
+	}
+	t.Cleanup(func() {
+		httpPostJSON = func(url, contentType string, body io.Reader) (*http.Response, error) {
+			return http.Post(url, contentType, body)
+		}
+	})
+
+	if err := client.SendMessageWithButton("hi", "button", "https://example.com"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSendMessageWithButtonHTTPError(t *testing.T) {
+	client := NewTelegramClient("token", "chat")
+
+	httpPostJSON = func(string, string, io.Reader) (*http.Response, error) {
+		return nil, errors.New("network")
+	}
+	t.Cleanup(func() {
+		httpPostJSON = func(url, contentType string, body io.Reader) (*http.Response, error) {
+			return http.Post(url, contentType, body)
+		}
+	})
+
+	if err := client.SendMessageWithButton("hi", "button", "https://example.com"); err == nil || !strings.Contains(err.Error(), "network") {
+		t.Fatalf("expected network error, got %v", err)
+	}
+}
+
+func TestSendMessageWithButtonNon200(t *testing.T) {
+	client := NewTelegramClient("token", "chat")
+
+	httpPostJSON = func(string, string, io.Reader) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad Request", Body: io.NopCloser(strings.NewReader("bad"))}, nil
+	}
+	t.Cleanup(func() {
+		httpPostJSON = func(url, contentType string, body io.Reader) (*http.Response, error) {
+			return http.Post(url, contentType, body)
+		}
+	})
+
+	if err := client.SendMessageWithButton("hi", "button", "https://example.com"); err == nil || !strings.Contains(err.Error(), "telegram send failed") {
+		t.Fatalf("expected telegram send failure, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- allow overriding the Docker cgroup path to make docker detection testable
- add unit tests covering config helpers, pagination, context utilities, and telegram client behavior

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d82fb3190c832c9a8f122ed94fff56