### PR TITLE
Add repository interfaces and order coverage

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,8 +96,10 @@ func getEnvDuration(key string, def time.Duration) time.Duration {
 	return def
 }
 
+var cgroupFilePath = "/proc/1/cgroup"
+
 func isRunningInDocker() bool {
-	if f, err := os.ReadFile("/proc/1/cgroup"); err == nil {
+	if f, err := os.ReadFile(cgroupFilePath); err == nil {
 		return strings.Contains(string(f), "docker")
 	}
 	return false

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,178 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGetEnv(t *testing.T) {
+	const key = "TEST_CONFIG_GET_ENV"
+	os.Unsetenv(key)
+
+	if got := getEnv(key, "default"); got != "default" {
+		t.Fatalf("expected default value, got %q", got)
+	}
+
+	if err := os.Setenv(key, "value"); err != nil {
+		t.Fatalf("setenv: %v", err)
+	}
+	defer os.Unsetenv(key)
+
+	if got := getEnv(key, "default"); got != "value" {
+		t.Fatalf("expected overridden value, got %q", got)
+	}
+}
+
+func TestGetEnvInt(t *testing.T) {
+	const key = "TEST_CONFIG_GET_ENV_INT"
+	os.Unsetenv(key)
+
+	if got := getEnvInt(key, 42); got != 42 {
+		t.Fatalf("expected default value, got %d", got)
+	}
+
+	if err := os.Setenv(key, "100"); err != nil {
+		t.Fatalf("setenv: %v", err)
+	}
+	if got := getEnvInt(key, 42); got != 100 {
+		t.Fatalf("expected parsed value, got %d", got)
+	}
+
+	if err := os.Setenv(key, "not-a-number"); err != nil {
+		t.Fatalf("setenv: %v", err)
+	}
+	if got := getEnvInt(key, 7); got != 7 {
+		t.Fatalf("expected fallback on parse error, got %d", got)
+	}
+
+	os.Unsetenv(key)
+}
+
+func TestGetEnvDuration(t *testing.T) {
+	const key = "TEST_CONFIG_GET_ENV_DURATION"
+	os.Unsetenv(key)
+
+	defaultDuration := 30 * time.Second
+	if got := getEnvDuration(key, defaultDuration); got != defaultDuration {
+		t.Fatalf("expected default duration, got %s", got)
+	}
+
+	if err := os.Setenv(key, "45s"); err != nil {
+		t.Fatalf("setenv: %v", err)
+	}
+	if got := getEnvDuration(key, defaultDuration); got != 45*time.Second {
+		t.Fatalf("expected parsed duration, got %s", got)
+	}
+
+	if err := os.Setenv(key, "not-a-duration"); err != nil {
+		t.Fatalf("setenv: %v", err)
+	}
+	if got := getEnvDuration(key, defaultDuration); got != defaultDuration {
+		t.Fatalf("expected fallback on parse error, got %s", got)
+	}
+
+	os.Unsetenv(key)
+}
+
+func TestIsRunningInDocker(t *testing.T) {
+	originalPath := cgroupFilePath
+	t.Cleanup(func() { cgroupFilePath = originalPath })
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "cgroup")
+
+	if err := os.WriteFile(file, []byte("12:freezer:/docker/123"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	cgroupFilePath = file
+	if !isRunningInDocker() {
+		t.Fatal("expected docker detection to return true")
+	}
+
+	if err := os.WriteFile(file, []byte("12:freezer:/container"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	if isRunningInDocker() {
+		t.Fatal("expected docker detection to return false")
+	}
+}
+
+func TestLoad(t *testing.T) {
+	originalPath := cgroupFilePath
+	t.Cleanup(func() { cgroupFilePath = originalPath })
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "cgroup")
+	if err := os.WriteFile(file, []byte("docker"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	cgroupFilePath = file
+
+	envs := map[string]string{
+		"APP_ENV":         "prod",
+		"APP_PORT":        "9090",
+		"APP_JWT_SECRET":  "supersecret",
+		"JWT_TTL":         "1h",
+		"FRONTEND_URL":    "https://example.com",
+		"DB_URL":          "postgres://localhost:5432/app",
+		"DB_MAX_CONNS":    "20",
+		"DB_MIN_CONNS":    "5",
+		"DB_CONN_TIMEOUT": "10s",
+		"DB_IDLE_TIMEOUT": "2m",
+		"TG_TOKEN":        "token",
+		"TG_CHAT":         "chat",
+	}
+
+	for k, v := range envs {
+		if err := os.Setenv(k, v); err != nil {
+			t.Fatalf("setenv %s: %v", k, err)
+		}
+		t.Cleanup(func(key string) func() {
+			return func() { os.Unsetenv(key) }
+		}(k))
+	}
+
+	cfg := Load()
+
+	if cfg.AppEnv != "prod" {
+		t.Fatalf("expected AppEnv prod, got %s", cfg.AppEnv)
+	}
+	if cfg.AppPort != "9090" {
+		t.Fatalf("expected AppPort 9090, got %s", cfg.AppPort)
+	}
+	if cfg.JWTSecret != "supersecret" {
+		t.Fatalf("expected JWTSecret supersecret, got %s", cfg.JWTSecret)
+	}
+	if cfg.JWTTTL != time.Hour {
+		t.Fatalf("expected JWTTTL 1h, got %s", cfg.JWTTTL)
+	}
+	if cfg.FrontendURL != "https://example.com" {
+		t.Fatalf("expected FrontendURL https://example.com, got %s", cfg.FrontendURL)
+	}
+
+	if !strings.Contains(cfg.DB.URL, "host.docker.internal") {
+		t.Fatalf("expected DB URL adjusted for docker, got %s", cfg.DB.URL)
+	}
+	if cfg.DB.MaxConns != 20 {
+		t.Fatalf("expected DB MaxConns 20, got %d", cfg.DB.MaxConns)
+	}
+	if cfg.DB.MinConns != 5 {
+		t.Fatalf("expected DB MinConns 5, got %d", cfg.DB.MinConns)
+	}
+	if cfg.DB.ConnTimeout != 10*time.Second {
+		t.Fatalf("expected DB ConnTimeout 10s, got %s", cfg.DB.ConnTimeout)
+	}
+	if cfg.DB.IdleTimeout != 2*time.Minute {
+		t.Fatalf("expected DB IdleTimeout 2m, got %s", cfg.DB.IdleTimeout)
+	}
+	if cfg.TG.TelegramToken != "token" {
+		t.Fatalf("expected TG token token, got %s", cfg.TG.TelegramToken)
+	}
+	if cfg.TG.TelegramChat != "chat" {
+		t.Fatalf("expected TG chat chat, got %s", cfg.TG.TelegramChat)
+	}
+}

--- a/internal/handlers/orders_test.go
+++ b/internal/handlers/orders_test.go
@@ -1,0 +1,153 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/Ramcache/travel-backend/internal/handlers"
+	"github.com/Ramcache/travel-backend/internal/models"
+	"github.com/Ramcache/travel-backend/internal/repository"
+	"github.com/Ramcache/travel-backend/internal/services"
+	"github.com/Ramcache/travel-backend/internal/testutil"
+)
+
+func TestOrderHandler_List_Defaults(t *testing.T) {
+	pool := testutil.NewMockDB(t)
+	defer pool.Verify(t)
+
+	pool.ExpectQueryRow(func(_ context.Context, sql string, _ []any) (pgx.Row, error) {
+		require.Contains(t, sql, "SELECT COUNT(*) FROM orders")
+		return testutil.NewSliceRow([]any{1}), nil
+	})
+
+	now := pool.Now()
+	pool.ExpectQuery(func(_ context.Context, sql string, args []any) (pgx.Rows, error) {
+		require.Contains(t, sql, "LIMIT $1 OFFSET $2")
+		require.Equal(t, []any{20, 0}, args)
+		rows := testutil.NewMockRows([][]any{{
+			1,
+			models.NullInt32{},
+			"Ivan",
+			"+7999",
+			"new",
+			false,
+			now,
+		}})
+		return rows, nil
+	})
+
+	repo := repository.NewOrderRepo(pool)
+	svc := services.NewOrderService(repo)
+	handler := handlers.NewOrderHandler(svc, zaptest.NewLogger(t).Sugar())
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/orders", nil)
+	w := httptest.NewRecorder()
+	handler.List(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Data services.OrdersWithTotal `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, 1, resp.Data.Total)
+	require.Len(t, resp.Data.Orders, 1)
+	require.Equal(t, "Ivan", resp.Data.Orders[0].UserName)
+}
+
+func TestOrderHandler_UpdateStatus_InvalidID(t *testing.T) {
+	pool := testutil.NewMockDB(t)
+	defer pool.Verify(t)
+	svc := services.NewOrderService(repository.NewOrderRepo(pool))
+	handler := handlers.NewOrderHandler(svc, zaptest.NewLogger(t).Sugar())
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/orders/abc/status", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "abc")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	handler.UpdateStatus(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestOrderHandler_UpdateStatus_NotFound(t *testing.T) {
+	pool := testutil.NewMockDB(t)
+	defer pool.Verify(t)
+
+	pool.ExpectExec(func(_ context.Context, sql string, args []any) (pgconn.CommandTag, error) {
+		require.Contains(t, sql, "UPDATE orders SET status")
+		require.Equal(t, []any{"done", 5}, args)
+		return pgconn.NewCommandTag("UPDATE 0"), nil
+	})
+
+	repo := repository.NewOrderRepo(pool)
+	svc := services.NewOrderService(repo)
+	handler := handlers.NewOrderHandler(svc, zaptest.NewLogger(t).Sugar())
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/orders/5/status?status=done", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "5")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	handler.UpdateStatus(w, req)
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestOrderHandler_MarkAsRead_Success(t *testing.T) {
+	pool := testutil.NewMockDB(t)
+	defer pool.Verify(t)
+
+	pool.ExpectExec(func(_ context.Context, sql string, args []any) (pgconn.CommandTag, error) {
+		require.Contains(t, sql, "UPDATE orders SET is_read = true")
+		require.Equal(t, []any{3}, args)
+		return pgconn.NewCommandTag("UPDATE 1"), nil
+	})
+
+	repo := repository.NewOrderRepo(pool)
+	svc := services.NewOrderService(repo)
+	handler := handlers.NewOrderHandler(svc, zaptest.NewLogger(t).Sugar())
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/orders/3/read", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "3")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	handler.MarkAsRead(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestOrderHandler_Delete_NotFound(t *testing.T) {
+	pool := testutil.NewMockDB(t)
+	defer pool.Verify(t)
+
+	pool.ExpectExec(func(_ context.Context, sql string, args []any) (pgconn.CommandTag, error) {
+		require.Contains(t, sql, "DELETE FROM orders")
+		require.Equal(t, []any{11}, args)
+		return pgconn.NewCommandTag("DELETE 0"), nil
+	})
+
+	repo := repository.NewOrderRepo(pool)
+	svc := services.NewOrderService(repo)
+	handler := handlers.NewOrderHandler(svc, zaptest.NewLogger(t).Sugar())
+
+	req := httptest.NewRequest(http.MethodDelete, "/admin/orders/11", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "11")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	handler.Delete(w, req)
+	require.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/internal/helpers/context_test.go
+++ b/internal/helpers/context_test.go
@@ -1,0 +1,20 @@
+package helpers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Ramcache/travel-backend/internal/helpers"
+)
+
+func TestSetAndGetUserID(t *testing.T) {
+	ctx := context.Background()
+	if got := helpers.GetUserID(ctx); got != 0 {
+		t.Fatalf("expected zero value when user id not set, got %d", got)
+	}
+
+	ctx = helpers.SetUserID(ctx, 42)
+	if got := helpers.GetUserID(ctx); got != 42 {
+		t.Fatalf("expected user id 42, got %d", got)
+	}
+}

--- a/internal/helpers/errors_test.go
+++ b/internal/helpers/errors_test.go
@@ -1,0 +1,23 @@
+package helpers_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Ramcache/travel-backend/internal/helpers"
+)
+
+func TestErrInvalidInput(t *testing.T) {
+	err := helpers.ErrInvalidInput("bad input")
+	if err.Error() != "bad input" {
+		t.Fatalf("expected error message to be preserved, got %q", err.Error())
+	}
+
+	if !helpers.IsInvalidInput(err) {
+		t.Fatal("expected error to be recognized as InvalidInputError")
+	}
+
+	if helpers.IsInvalidInput(errors.New("other")) {
+		t.Fatal("expected IsInvalidInput to return false for other error types")
+	}
+}

--- a/internal/helpers/paginated_test.go
+++ b/internal/helpers/paginated_test.go
@@ -1,0 +1,25 @@
+package helpers_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Ramcache/travel-backend/internal/helpers"
+)
+
+func TestPaginatedResponseJSON(t *testing.T) {
+	resp := helpers.PaginatedResponse[int]{
+		Total: 2,
+		Items: []int{1, 2},
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("json marshal: %v", err)
+	}
+
+	expected := `{"total":2,"items":[1,2]}`
+	if string(data) != expected {
+		t.Fatalf("expected %s, got %s", expected, string(data))
+	}
+}

--- a/internal/helpers/telegram.go
+++ b/internal/helpers/telegram.go
@@ -9,6 +9,13 @@ import (
 	"net/url"
 )
 
+var (
+	httpPostForm = http.PostForm
+	httpPostJSON = func(url, contentType string, body io.Reader) (*http.Response, error) {
+		return http.Post(url, contentType, body)
+	}
+)
+
 type TelegramClient struct {
 	Token  string
 	ChatID string
@@ -21,7 +28,7 @@ func NewTelegramClient(token, chatID string) *TelegramClient {
 func (t *TelegramClient) SendMessage(text string) error {
 	apiURL := fmt.Sprintf("https://api.telegram.org/bot%s/sendMessage", t.Token)
 
-	resp, err := http.PostForm(apiURL, url.Values{
+	resp, err := httpPostForm(apiURL, url.Values{
 		"chat_id":    {t.ChatID},
 		"text":       {text},
 		"parse_mode": {"HTML"},
@@ -57,7 +64,7 @@ func (t *TelegramClient) SendMessageWithButton(text, buttonText, buttonURL strin
 	}
 
 	body, _ := json.Marshal(payload)
-	resp, err := http.Post(apiURL, "application/json", bytes.NewReader(body))
+	resp, err := httpPostJSON(apiURL, "application/json", bytes.NewReader(body))
 	if err != nil {
 		return err
 	}

--- a/internal/helpers/telegram_test.go
+++ b/internal/helpers/telegram_test.go
@@ -1,0 +1,132 @@
+package helpers
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestNewTelegramClient(t *testing.T) {
+	client := NewTelegramClient("token", "chat")
+	if client.Token != "token" || client.ChatID != "chat" {
+		t.Fatalf("unexpected client fields: %+v", client)
+	}
+}
+
+func TestSendMessageSuccess(t *testing.T) {
+	client := NewTelegramClient("token", "chat")
+
+	called := false
+	httpPostForm = func(url string, data url.Values) (*http.Response, error) {
+		called = true
+		if data.Get("chat_id") != "chat" {
+			t.Fatalf("unexpected chat id %s", data.Get("chat_id"))
+		}
+		if data.Get("text") != "hello" {
+			t.Fatalf("unexpected text %s", data.Get("text"))
+		}
+		return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Body: io.NopCloser(strings.NewReader(""))}, nil
+	}
+	t.Cleanup(func() { httpPostForm = http.PostForm })
+
+	if err := client.SendMessage("hello"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !called {
+		t.Fatal("expected httpPostForm to be called")
+	}
+}
+
+func TestSendMessageHTTPError(t *testing.T) {
+	client := NewTelegramClient("token", "chat")
+
+	httpPostForm = func(string, url.Values) (*http.Response, error) {
+		return nil, errors.New("network")
+	}
+	t.Cleanup(func() { httpPostForm = http.PostForm })
+
+	if err := client.SendMessage("hello"); err == nil || !strings.Contains(err.Error(), "network") {
+		t.Fatalf("expected network error, got %v", err)
+	}
+}
+
+func TestSendMessageNon200(t *testing.T) {
+	client := NewTelegramClient("token", "chat")
+
+	httpPostForm = func(string, url.Values) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad Request", Body: io.NopCloser(strings.NewReader("bad"))}, nil
+	}
+	t.Cleanup(func() { httpPostForm = http.PostForm })
+
+	if err := client.SendMessage("hello"); err == nil || !strings.Contains(err.Error(), "telegram send failed") {
+		t.Fatalf("expected telegram send failure, got %v", err)
+	}
+}
+
+func TestSendMessageWithButtonSuccess(t *testing.T) {
+	client := NewTelegramClient("token", "chat")
+
+	httpPostJSON = func(url, contentType string, body io.Reader) (*http.Response, error) {
+		if !strings.Contains(url, "token") {
+			t.Fatalf("unexpected url %s", url)
+		}
+		if contentType != "application/json" {
+			t.Fatalf("unexpected content type %s", contentType)
+		}
+		data, err := io.ReadAll(body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if !strings.Contains(string(data), "button") {
+			t.Fatalf("expected button text in payload, got %s", string(data))
+		}
+		return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Body: io.NopCloser(strings.NewReader(""))}, nil
+	}
+	t.Cleanup(func() {
+		httpPostJSON = func(url, contentType string, body io.Reader) (*http.Response, error) {
+			return http.Post(url, contentType, body)
+		}
+	})
+
+	if err := client.SendMessageWithButton("hi", "button", "https://example.com"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSendMessageWithButtonHTTPError(t *testing.T) {
+	client := NewTelegramClient("token", "chat")
+
+	httpPostJSON = func(string, string, io.Reader) (*http.Response, error) {
+		return nil, errors.New("network")
+	}
+	t.Cleanup(func() {
+		httpPostJSON = func(url, contentType string, body io.Reader) (*http.Response, error) {
+			return http.Post(url, contentType, body)
+		}
+	})
+
+	if err := client.SendMessageWithButton("hi", "button", "https://example.com"); err == nil || !strings.Contains(err.Error(), "network") {
+		t.Fatalf("expected network error, got %v", err)
+	}
+}
+
+func TestSendMessageWithButtonNon200(t *testing.T) {
+	client := NewTelegramClient("token", "chat")
+
+	httpPostJSON = func(string, string, io.Reader) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad Request", Body: io.NopCloser(strings.NewReader("bad"))}, nil
+	}
+	t.Cleanup(func() {
+		httpPostJSON = func(url, contentType string, body io.Reader) (*http.Response, error) {
+			return http.Post(url, contentType, body)
+		}
+	})
+
+	if err := client.SendMessageWithButton("hi", "button", "https://example.com"); err == nil || !strings.Contains(err.Error(), "telegram send failed") {
+		t.Fatalf("expected telegram send failure, got %v", err)
+	}
+}

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -1,0 +1,19 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// DB abstracts the subset of pgxpool.Pool methods used by repositories.
+//
+// It matches the method set of *pgxpool.Pool so the production code can pass
+// a real connection pool while tests can provide lightweight fakes without
+// spinning up a database.
+type DB interface {
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+}

--- a/internal/repository/mock_pool_test.go
+++ b/internal/repository/mock_pool_test.go
@@ -1,0 +1,183 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+type mockPool struct {
+	t             *testing.T
+	queryCalls    []func(context.Context, string, []any) (pgx.Rows, error)
+	queryRowCalls []func(context.Context, string, []any) (pgx.Row, error)
+	execCalls     []func(context.Context, string, []any) (pgconn.CommandTag, error)
+
+	queryIdx    int
+	queryRowIdx int
+	execIdx     int
+}
+
+func newMockPool(t *testing.T) *mockPool {
+	t.Helper()
+	return &mockPool{t: t}
+}
+
+func (m *mockPool) expectQuery(fn func(context.Context, string, []any) (pgx.Rows, error)) {
+	m.queryCalls = append(m.queryCalls, fn)
+}
+
+func (m *mockPool) expectQueryRow(fn func(context.Context, string, []any) (pgx.Row, error)) {
+	m.queryRowCalls = append(m.queryRowCalls, fn)
+}
+
+func (m *mockPool) expectExec(fn func(context.Context, string, []any) (pgconn.CommandTag, error)) {
+	m.execCalls = append(m.execCalls, fn)
+}
+
+func (m *mockPool) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	if m.queryIdx >= len(m.queryCalls) {
+		m.t.Fatalf("unexpected Query call: %s", sql)
+	}
+	fn := m.queryCalls[m.queryIdx]
+	m.queryIdx++
+	return fn(ctx, sql, args)
+}
+
+func (m *mockPool) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
+	if m.queryRowIdx >= len(m.queryRowCalls) {
+		m.t.Fatalf("unexpected QueryRow call: %s", sql)
+	}
+	fn := m.queryRowCalls[m.queryRowIdx]
+	m.queryRowIdx++
+	row, err := fn(ctx, sql, args)
+	if err != nil {
+		return &errorRow{err: err}
+	}
+	return row
+}
+
+func (m *mockPool) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	if m.execIdx >= len(m.execCalls) {
+		m.t.Fatalf("unexpected Exec call: %s", sql)
+	}
+	fn := m.execCalls[m.execIdx]
+	m.execIdx++
+	return fn(ctx, sql, args)
+}
+
+func (m *mockPool) verify(t *testing.T) {
+	t.Helper()
+	if m.queryIdx != len(m.queryCalls) {
+		t.Fatalf("expected %d Query calls, got %d", len(m.queryCalls), m.queryIdx)
+	}
+	if m.queryRowIdx != len(m.queryRowCalls) {
+		t.Fatalf("expected %d QueryRow calls, got %d", len(m.queryRowCalls), m.queryRowIdx)
+	}
+	if m.execIdx != len(m.execCalls) {
+		t.Fatalf("expected %d Exec calls, got %d", len(m.execCalls), m.execIdx)
+	}
+}
+
+type errorRow struct {
+	err error
+}
+
+func (r *errorRow) Scan(dest ...any) error { return r.err }
+
+type sliceRow struct {
+	values []any
+	err    error
+}
+
+func newSliceRow(values []any) *sliceRow {
+	return &sliceRow{values: values}
+}
+
+func (r *sliceRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	return assignValues(dest, r.values)
+}
+
+type mockRows struct {
+	data [][]any
+	idx  int
+	err  error
+}
+
+func newMockRows(data [][]any) *mockRows { return &mockRows{data: data} }
+
+func (r *mockRows) Close()                                       {}
+func (r *mockRows) Err() error                                   { return r.err }
+func (r *mockRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *mockRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *mockRows) RawValues() [][]byte                          { return nil }
+func (r *mockRows) Conn() *pgx.Conn                              { return nil }
+
+func (r *mockRows) Next() bool {
+	if r.err != nil {
+		return false
+	}
+	if r.idx >= len(r.data) {
+		return false
+	}
+	r.idx++
+	return true
+}
+
+func (r *mockRows) Scan(dest ...any) error {
+	if r.idx == 0 || r.idx > len(r.data) {
+		return fmt.Errorf("scan called without Next")
+	}
+	row := r.data[r.idx-1]
+	return assignValues(dest, row)
+}
+
+func (r *mockRows) Values() ([]any, error) {
+	if r.idx == 0 || r.idx > len(r.data) {
+		return nil, fmt.Errorf("values called without Next")
+	}
+	row := r.data[r.idx-1]
+	out := make([]any, len(row))
+	copy(out, row)
+	return out, nil
+}
+
+func assignValues(dest []any, values []any) error {
+	if len(dest) != len(values) {
+		return fmt.Errorf("expected %d dest values, got %d", len(values), len(dest))
+	}
+	for i := range dest {
+		if err := assignValue(dest[i], values[i]); err != nil {
+			return fmt.Errorf("assign column %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func assignValue(dest any, value any) error {
+	rv := reflect.ValueOf(dest)
+	if rv.Kind() != reflect.Pointer || rv.IsNil() {
+		return fmt.Errorf("dest must be non-nil pointer, got %T", dest)
+	}
+	target := rv.Elem()
+	if value == nil {
+		target.Set(reflect.Zero(target.Type()))
+		return nil
+	}
+	sv := reflect.ValueOf(value)
+	if sv.Type().AssignableTo(target.Type()) {
+		target.Set(sv)
+		return nil
+	}
+	if sv.Type().ConvertibleTo(target.Type()) {
+		target.Set(sv.Convert(target.Type()))
+		return nil
+	}
+	return fmt.Errorf("cannot assign %T to %s", value, target.Type())
+}

--- a/internal/repository/orders.go
+++ b/internal/repository/orders.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
 	"github.com/Ramcache/travel-backend/internal/models"
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 type OrderRepo struct {
-	db *pgxpool.Pool
+	db DB
 }
 
-func NewOrderRepo(db *pgxpool.Pool) *OrderRepo {
+func NewOrderRepo(db DB) *OrderRepo {
 	return &OrderRepo{db: db}
 }
 

--- a/internal/repository/orders_test.go
+++ b/internal/repository/orders_test.go
@@ -1,0 +1,84 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Ramcache/travel-backend/internal/models"
+)
+
+func TestOrderRepo_Count_WithFilters(t *testing.T) {
+	pool := newMockPool(t)
+	defer pool.verify(t)
+
+	pool.expectQueryRow(func(_ context.Context, sql string, args []any) (pgx.Row, error) {
+		require.Contains(t, sql, "SELECT COUNT(*) FROM orders")
+		require.True(t, strings.Contains(sql, "status = $1"))
+		require.True(t, strings.Contains(sql, "user_phone ILIKE $2"))
+		require.True(t, strings.Contains(sql, "is_read = $3"))
+		require.Len(t, args, 3)
+		require.Equal(t, "done", args[0])
+		require.Equal(t, "%+7999%", args[1])
+		require.Equal(t, true, args[2])
+		return newSliceRow([]any{5}), nil
+	})
+
+	repo := NewOrderRepo(pool)
+	total, err := repo.Count(context.Background(), "done", "+7999", ptrBool(true))
+	require.NoError(t, err)
+	require.Equal(t, 5, total)
+}
+
+func TestOrderRepo_List_ReturnsOrders(t *testing.T) {
+	pool := newMockPool(t)
+	defer pool.verify(t)
+
+	now := time.Now()
+	pool.expectQuery(func(_ context.Context, query string, args []any) (pgx.Rows, error) {
+		require.Contains(t, query, "FROM orders")
+		require.Contains(t, query, "LIMIT $1 OFFSET $2")
+		require.Equal(t, []any{10, 5}, args)
+		rows := newMockRows([][]any{{
+			1,
+			models.NullInt32{NullInt32: sql.NullInt32{Int32: 3, Valid: true}},
+			"Ivan",
+			"+7999",
+			"new",
+			true,
+			now,
+		}})
+		return rows, nil
+	})
+
+	repo := NewOrderRepo(pool)
+	orders, err := repo.List(context.Background(), 10, 5, "", "", nil)
+	require.NoError(t, err)
+	require.Len(t, orders, 1)
+	require.Equal(t, "Ivan", orders[0].UserName)
+	require.True(t, orders[0].TripID.Valid)
+}
+
+func TestOrderRepo_UpdateStatus_NotFound(t *testing.T) {
+	pool := newMockPool(t)
+	defer pool.verify(t)
+
+	pool.expectExec(func(_ context.Context, query string, args []any) (pgconn.CommandTag, error) {
+		require.Contains(t, query, "UPDATE orders SET status")
+		require.Equal(t, []any{"canceled", 9}, args)
+		return pgconn.NewCommandTag("UPDATE 0"), nil
+	})
+
+	repo := NewOrderRepo(pool)
+	err := repo.UpdateStatus(context.Background(), 9, "canceled")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "order not found")
+}
+
+func ptrBool(v bool) *bool { return &v }

--- a/internal/repository/trip.go
+++ b/internal/repository/trip.go
@@ -6,16 +6,15 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/Ramcache/travel-backend/internal/models"
 )
 
 type TripRepository struct {
-	Db *pgxpool.Pool
+	Db DB
 }
 
-func NewTripRepository(db *pgxpool.Pool) *TripRepository {
+func NewTripRepository(db DB) *TripRepository {
 	return &TripRepository{Db: db}
 }
 

--- a/internal/repository/trip_test.go
+++ b/internal/repository/trip_test.go
@@ -1,0 +1,141 @@
+package repository
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTripRepository_List_WithFilters(t *testing.T) {
+	pool := newMockPool(t)
+	defer pool.verify(t)
+
+	now := time.Now()
+	deadline := now.Add(24 * time.Hour)
+
+	pool.expectQuery(func(_ context.Context, sql string, args []any) (pgx.Rows, error) {
+		require.Contains(t, sql, "FROM trips")
+		require.Contains(t, sql, "WHERE")
+		require.Len(t, args, 2)
+		require.Equal(t, "Moscow", args[0])
+		require.Equal(t, "пляжный", args[1])
+
+		rows := newMockRows([][]any{{
+			1,
+			"Trip",
+			"Desc",
+			"photo.jpg",
+			"Moscow",
+			"пляжный",
+			"summer",
+			1500.0,
+			"RUB",
+			now,
+			now.Add(48 * time.Hour),
+			&deadline,
+			true,
+			10,
+			2,
+			now,
+			now,
+		}})
+		return rows, nil
+	})
+
+	repo := NewTripRepository(pool)
+	trips, err := repo.List(context.Background(), "Moscow", "пляжный", "")
+	require.NoError(t, err)
+	require.Len(t, trips, 1)
+	require.Equal(t, "Trip", trips[0].Title)
+	require.True(t, trips[0].Main)
+}
+
+func TestTripRepository_GetByID_NotFound(t *testing.T) {
+	pool := newMockPool(t)
+	defer pool.verify(t)
+
+	pool.expectQueryRow(func(_ context.Context, sql string, args []any) (pgx.Row, error) {
+		require.True(t, strings.Contains(sql, "FROM trips"))
+		require.Equal(t, []any{99}, args)
+		return nil, pgx.ErrNoRows
+	})
+
+	repo := NewTripRepository(pool)
+	trip, err := repo.GetByID(context.Background(), 99)
+	require.Nil(t, trip)
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestTripRepository_Delete_NotFound(t *testing.T) {
+	pool := newMockPool(t)
+	defer pool.verify(t)
+
+	pool.expectExec(func(_ context.Context, sql string, args []any) (pgconn.CommandTag, error) {
+		require.Contains(t, sql, "DELETE FROM trips")
+		require.Equal(t, []any{5}, args)
+		return pgconn.NewCommandTag("DELETE 0"), nil
+	})
+
+	repo := NewTripRepository(pool)
+	err := repo.Delete(context.Background(), 5)
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestTripRepository_ResetMain_WithExclude(t *testing.T) {
+	pool := newMockPool(t)
+	defer pool.verify(t)
+
+	pool.expectExec(func(_ context.Context, sql string, args []any) (pgconn.CommandTag, error) {
+		require.Contains(t, sql, "UPDATE trips SET main=false WHERE id <> $1")
+		require.Equal(t, []any{7}, args)
+		return pgconn.NewCommandTag("UPDATE 3"), nil
+	})
+
+	repo := NewTripRepository(pool)
+	id := 7
+	require.NoError(t, repo.ResetMain(context.Background(), &id))
+}
+
+func TestTripRepository_Popular(t *testing.T) {
+	pool := newMockPool(t)
+	defer pool.verify(t)
+
+	now := time.Now()
+
+	pool.expectQuery(func(_ context.Context, sql string, args []any) (pgx.Rows, error) {
+		require.Contains(t, sql, "ORDER BY buys_count DESC")
+		require.Equal(t, []any{3}, args)
+		rows := newMockRows([][]any{{
+			1,
+			"Trip",
+			"Desc",
+			"photo.jpg",
+			"Moscow",
+			"пляжный",
+			"summer",
+			2500.0,
+			"RUB",
+			now,
+			now.Add(72 * time.Hour),
+			(*time.Time)(nil),
+			false,
+			100,
+			20,
+			now,
+			now,
+		}})
+		return rows, nil
+	})
+
+	repo := NewTripRepository(pool)
+	trips, err := repo.Popular(context.Background(), 3)
+	require.NoError(t, err)
+	require.Len(t, trips, 1)
+	require.Equal(t, 100, trips[0].ViewsCount)
+	require.Equal(t, 20, trips[0].BuysCount)
+}

--- a/internal/services/orders_test.go
+++ b/internal/services/orders_test.go
@@ -1,0 +1,96 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Ramcache/travel-backend/internal/models"
+	"github.com/Ramcache/travel-backend/internal/repository"
+	"github.com/Ramcache/travel-backend/internal/testutil"
+)
+
+func TestOrderService_Create(t *testing.T) {
+	pool := testutil.NewMockDB(t)
+	defer pool.Verify(t)
+
+	createdAt := pool.Now()
+	pool.ExpectQueryRow(func(_ context.Context, query string, args []any) (pgx.Row, error) {
+		require.Contains(t, query, "INSERT INTO orders")
+		require.Len(t, args, 4)
+		tripArg, ok := args[0].(sql.NullInt32)
+		require.True(t, ok)
+		require.Equal(t, int32(7), tripArg.Int32)
+		require.True(t, tripArg.Valid)
+		require.Equal(t, "Ivan", args[1])
+		require.Equal(t, "+7999", args[2])
+		require.Equal(t, "new", args[3])
+		return testutil.NewSliceRow([]any{42, createdAt}), nil
+	})
+
+	repo := repository.NewOrderRepo(pool)
+	svc := NewOrderService(repo)
+
+	order, err := svc.Create(context.Background(), 7, "Ivan", "+7999")
+	require.NoError(t, err)
+	require.Equal(t, 42, order.ID)
+	require.Equal(t, "new", order.Status)
+	require.Equal(t, "+7999", order.UserPhone)
+}
+
+func TestOrderService_List(t *testing.T) {
+	pool := testutil.NewMockDB(t)
+	defer pool.Verify(t)
+
+	pool.ExpectQueryRow(func(_ context.Context, query string, _ []any) (pgx.Row, error) {
+		require.Contains(t, query, "SELECT COUNT(*) FROM orders")
+		return testutil.NewSliceRow([]any{2}), nil
+	})
+
+	now := pool.Now()
+	pool.ExpectQuery(func(_ context.Context, query string, args []any) (pgx.Rows, error) {
+		require.Contains(t, query, "LIMIT $1 OFFSET $2")
+		require.Equal(t, []any{15, 30}, args)
+		rows := testutil.NewMockRows([][]any{{
+			1,
+			models.NullInt32{NullInt32: sql.NullInt32{Valid: false}},
+			"Maria",
+			"+7888",
+			"new",
+			false,
+			now,
+		}})
+		return rows, nil
+	})
+
+	repo := repository.NewOrderRepo(pool)
+	svc := NewOrderService(repo)
+
+	result, err := svc.List(context.Background(), 15, 30, "", "", nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, result.Total)
+	require.Len(t, result.Orders, 1)
+	require.Equal(t, "Maria", result.Orders[0].UserName)
+}
+
+func TestOrderService_UpdateStatus_Error(t *testing.T) {
+	pool := testutil.NewMockDB(t)
+	defer pool.Verify(t)
+
+	pool.ExpectExec(func(_ context.Context, query string, args []any) (pgconn.CommandTag, error) {
+		require.Contains(t, query, "UPDATE orders SET status")
+		require.Equal(t, []any{"done", 5}, args)
+		return pgconn.CommandTag{}, errors.New("boom")
+	})
+
+	repo := repository.NewOrderRepo(pool)
+	svc := NewOrderService(repo)
+
+	err := svc.UpdateStatus(context.Background(), 5, "done")
+	require.EqualError(t, err, "boom")
+}

--- a/internal/testutil/mockdb.go
+++ b/internal/testutil/mockdb.go
@@ -1,0 +1,202 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// MockDB implements repository.DB and records expectations for queries executed
+// by services and handlers during tests.
+type MockDB struct {
+	t             *testing.T
+	now           time.Time
+	queryCalls    []func(context.Context, string, []any) (pgx.Rows, error)
+	queryRowCalls []func(context.Context, string, []any) (pgx.Row, error)
+	execCalls     []func(context.Context, string, []any) (pgconn.CommandTag, error)
+
+	queryIdx    int
+	queryRowIdx int
+	execIdx     int
+}
+
+// NewMockDB creates a MockDB bound to the provided testing.T.
+func NewMockDB(t *testing.T) *MockDB {
+	t.Helper()
+	return &MockDB{t: t, now: time.Now()}
+}
+
+// Now returns the deterministic timestamp used when building mock rows.
+func (m *MockDB) Now() time.Time { return m.now }
+
+// ExpectQuery registers a callback that will be invoked for the next Query call.
+func (m *MockDB) ExpectQuery(fn func(context.Context, string, []any) (pgx.Rows, error)) {
+	m.queryCalls = append(m.queryCalls, fn)
+}
+
+// ExpectQueryRow registers a callback for the next QueryRow call.
+func (m *MockDB) ExpectQueryRow(fn func(context.Context, string, []any) (pgx.Row, error)) {
+	m.queryRowCalls = append(m.queryRowCalls, fn)
+}
+
+// ExpectExec registers a callback for the next Exec call.
+func (m *MockDB) ExpectExec(fn func(context.Context, string, []any) (pgconn.CommandTag, error)) {
+	m.execCalls = append(m.execCalls, fn)
+}
+
+// Verify ensures that all registered expectations were satisfied.
+func (m *MockDB) Verify(t *testing.T) {
+	t.Helper()
+	if m.queryIdx != len(m.queryCalls) {
+		t.Fatalf("expected %d Query calls, got %d", len(m.queryCalls), m.queryIdx)
+	}
+	if m.queryRowIdx != len(m.queryRowCalls) {
+		t.Fatalf("expected %d QueryRow calls, got %d", len(m.queryRowCalls), m.queryRowIdx)
+	}
+	if m.execIdx != len(m.execCalls) {
+		t.Fatalf("expected %d Exec calls, got %d", len(m.execCalls), m.execIdx)
+	}
+}
+
+func (m *MockDB) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	if m.queryIdx >= len(m.queryCalls) {
+		m.t.Fatalf("unexpected Query call: %s", sql)
+	}
+	fn := m.queryCalls[m.queryIdx]
+	m.queryIdx++
+	return fn(ctx, sql, args)
+}
+
+func (m *MockDB) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
+	if m.queryRowIdx >= len(m.queryRowCalls) {
+		m.t.Fatalf("unexpected QueryRow call: %s", sql)
+	}
+	fn := m.queryRowCalls[m.queryRowIdx]
+	m.queryRowIdx++
+	row, err := fn(ctx, sql, args)
+	if err != nil {
+		return &errorRow{err: err}
+	}
+	return row
+}
+
+func (m *MockDB) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	if m.execIdx >= len(m.execCalls) {
+		m.t.Fatalf("unexpected Exec call: %s", sql)
+	}
+	fn := m.execCalls[m.execIdx]
+	m.execIdx++
+	return fn(ctx, sql, args)
+}
+
+// Row is the minimal interface returned by ExpectQueryRow callbacks.
+type Row interface{ Scan(dest ...any) error }
+
+// Rows is the minimal interface returned by ExpectQuery callbacks.
+type Rows interface {
+	pgx.Rows
+}
+
+type errorRow struct{ err error }
+
+func (r *errorRow) Scan(dest ...any) error { return r.err }
+
+// SliceRow is a helper implementing pgx.Row backed by a slice of values.
+type SliceRow struct {
+	values []any
+	err    error
+}
+
+// NewSliceRow creates a row that scans the provided values into destination pointers.
+func NewSliceRow(values []any) *SliceRow { return &SliceRow{values: values} }
+
+func (r *SliceRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	return assignValues(dest, r.values)
+}
+
+// MockRows implements pgx.Rows for deterministic result sets.
+type MockRows struct {
+	data [][]any
+	idx  int
+	err  error
+}
+
+// NewMockRows constructs a MockRows instance that iterates over the provided data.
+func NewMockRows(data [][]any) *MockRows { return &MockRows{data: data} }
+
+func (r *MockRows) Close()                                       {}
+func (r *MockRows) Err() error                                   { return r.err }
+func (r *MockRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *MockRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *MockRows) RawValues() [][]byte                          { return nil }
+func (r *MockRows) Conn() *pgx.Conn                              { return nil }
+
+func (r *MockRows) Next() bool {
+	if r.err != nil {
+		return false
+	}
+	if r.idx >= len(r.data) {
+		return false
+	}
+	r.idx++
+	return true
+}
+
+func (r *MockRows) Scan(dest ...any) error {
+	if r.idx == 0 || r.idx > len(r.data) {
+		return fmt.Errorf("scan called without Next")
+	}
+	return assignValues(dest, r.data[r.idx-1])
+}
+
+func (r *MockRows) Values() ([]any, error) {
+	if r.idx == 0 || r.idx > len(r.data) {
+		return nil, fmt.Errorf("values called without Next")
+	}
+	row := r.data[r.idx-1]
+	out := make([]any, len(row))
+	copy(out, row)
+	return out, nil
+}
+
+func assignValues(dest []any, values []any) error {
+	if len(dest) != len(values) {
+		return fmt.Errorf("expected %d dest values, got %d", len(values), len(dest))
+	}
+	for i := range dest {
+		if err := assignValue(dest[i], values[i]); err != nil {
+			return fmt.Errorf("assign column %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func assignValue(dest any, value any) error {
+	rv := reflect.ValueOf(dest)
+	if rv.Kind() != reflect.Pointer || rv.IsNil() {
+		return fmt.Errorf("dest must be pointer")
+	}
+	target := rv.Elem()
+	if value == nil {
+		target.Set(reflect.Zero(target.Type()))
+		return nil
+	}
+	sv := reflect.ValueOf(value)
+	if sv.Type().AssignableTo(target.Type()) {
+		target.Set(sv)
+		return nil
+	}
+	if sv.Type().ConvertibleTo(target.Type()) {
+		target.Set(sv.Convert(target.Type()))
+		return nil
+	}
+	return fmt.Errorf("cannot assign %T to %s", value, target.Type())
+}


### PR DESCRIPTION
## Summary
- abstract repository database usage behind a small interface so tests can inject fakes
- add reusable pgx mock helpers and unit tests for trip and order repositories
- cover order service and handler flows with new mock database utilities

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d82fb3190c832c9a8f122ed94fff56